### PR TITLE
feat: add build and test workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      SOLANA_VERSION: ${{ vars.ORG_SOLANA_VERSION }}
+      SOLANA_VERSION: ${{ secrets.ORG_SOLANA_VERSION }}
       SOLANA_PATH: /home/runner/.local/share/solana/install/active_release/bin
       PROGRAM: protocol_event
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,85 @@
+name: CI - Build Protocol Event Program
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
+    paths:
+      - 'programs/protocol_event/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: self-hosted
+
+    env:
+      SOLANA_VERSION: ${{ vars.ORG_SOLANA_VERSION }}
+      SOLANA_PATH: /home/runner/.local/share/solana/install/active_release/bin
+      PROGRAM: protocol_event
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Solana Cache
+        id: cache-solana
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/.local/share/solana/
+          key: ${{ runner.os }}-solana-${{ env.SOLANA_VERSION }}
+
+      - name: Yarn Cache
+        uses: actions/setup-node@v2
+        with:
+          cache: 'yarn'
+
+      - name: Cargo Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/.cargo/bin/
+            /home/runner/.cargo/registry/index/
+            /home/runner/.cargo/registry/cache/
+            /home/runner/.cargo/git/db/
+            /home/runner/.cargo/.crates.toml
+            /home/runner/.cargo/.crates2.json
+            target/bpfel-unknown-unknown/
+            target/debug/
+            target/release/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Solana
+        if: steps.cache-solana.outputs.cache-hit != 'true'
+        run: |
+          rustup default stable
+          SOLANA_INSTALLER_URL=https://release.solana.com/${{ env.SOLANA_VERSION }}/install
+          echo $SOLANA_INSTALLER_URL
+          sh -c "$(curl -sSfL $SOLANA_INSTALLER_URL)"
+
+      - name: Set Solana Path
+        run: |
+          echo "${{ env.SOLANA_PATH }}" >> $GITHUB_PATH
+
+      - name: Check Solana Version
+        run: |
+          solana --version
+
+      - name: Install anchor
+        run: |
+          sudo apt update
+          sudo apt install -y libudev-dev
+          sudo apt install -y pkg-config
+          ANCHOR_VERSION=`grep -A1 'name = "anchor-lang"' Cargo.lock | tail -n 1 | cut -d = -f 2 | xargs`
+          echo "Installing anchor-cli version ${ANCHOR_VERSION}"
+          cargo install --git https://github.com/project-serum/anchor --tag v${ANCHOR_VERSION} anchor-cli --locked
+          anchor --version
+
+      - name: Anchor build & test
+        run: |
+          set -o pipefail
+          solana-keygen new --no-bip39-passphrase --force
+          yarn
+          yarn test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,11 +16,11 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: projectserum/build:v0.27.0
 
     env:
       SOLANA_VERSION: ${{ secrets.ORG_SOLANA_VERSION }}
       SOLANA_PATH: /home/runner/.local/share/solana/install/active_release/bin
-      PROGRAM: protocol_event
 
     steps:
       - name: Checkout repo
@@ -53,10 +53,13 @@ jobs:
             target/release/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Rustup
+        run: |           
+          rustup default stable
+
       - name: Install Solana
         if: steps.cache-solana.outputs.cache-hit != 'true'
         run: |
-          rustup default stable
           SOLANA_INSTALLER_URL=https://release.solana.com/${{ env.SOLANA_VERSION }}/install
           echo $SOLANA_INSTALLER_URL
           sh -c "$(curl -sSfL $SOLANA_INSTALLER_URL)"
@@ -69,19 +72,8 @@ jobs:
         run: |
           solana --version
 
-      - name: Install anchor
-        run: |
-          sudo apt update
-          sudo apt install -y libudev-dev
-          sudo apt install -y pkg-config
-          ANCHOR_VERSION=`grep -A1 'name = "anchor-lang"' Cargo.lock | tail -n 1 | cut -d = -f 2 | xargs`
-          echo "Installing anchor-cli version ${ANCHOR_VERSION}"
-          cargo install --git https://github.com/project-serum/anchor --tag v${ANCHOR_VERSION} anchor-cli --locked
-          anchor --version
-
       - name: Anchor build & test
         run: |
-          set -o pipefail
           solana-keygen new --no-bip39-passphrase --force
           yarn
           yarn test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     env:
       SOLANA_VERSION: ${{ vars.ORG_SOLANA_VERSION }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,6 +2,8 @@ name: CI - Build Protocol Event Program
 
 on:
   pull_request:
+    branches:
+      - '**'
     types: [ opened, reopened, synchronize, ready_for_review ]
     paths:
       - 'programs/protocol_event/**'

--- a/tests/event/create_event.ts
+++ b/tests/event/create_event.ts
@@ -17,7 +17,7 @@ describe("Create Event", () => {
     const startTime = 1924200000;
 
     const oracle = "TEST ORACLE";
-    const reference = "TEST REFERENCE";
+    const reference = "A TEST REFERENCE";
 
     const participants = ["A", "B", "C"];
 


### PR DESCRIPTION
Add a workflow for building and testing the program
- Runs on a github hosted runner; `ubuntu-latest` as github recommend not using self-hosted runners on Public repos (some reading material https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
- Uses the Anchor docker image to speed up anchor install times - otherwise the run takes ~20mins https://hub.docker.com/r/projectserum/build/tags. This is still part of the `projectserum` org, but is still supported by the current anchor developers so I think it is fine to use for now