### PR TITLE
feat: update participant instructions

### DIFF
--- a/programs/protocol_event/src/context.rs
+++ b/programs/protocol_event/src/context.rs
@@ -117,3 +117,11 @@ pub struct CreateParticipant<'info> {
     #[account(address = system_program::ID)]
     pub system_program: Program<'info, System>,
 }
+
+#[derive(Accounts)]
+pub struct UpdateParticipant<'info> {
+    #[account(mut, has_one = authority)]
+    pub participant: Account<'info, Participant>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
+}

--- a/programs/protocol_event/src/context.rs
+++ b/programs/protocol_event/src/context.rs
@@ -47,7 +47,6 @@ pub struct UpdateEvent<'info> {
     pub event: Account<'info, Event>,
     pub category: Account<'info, Category>,
 
-    #[account(mut)]
     pub authority: Signer<'info>,
 }
 
@@ -122,6 +121,5 @@ pub struct CreateParticipant<'info> {
 pub struct UpdateParticipant<'info> {
     #[account(mut, has_one = authority)]
     pub participant: Account<'info, Participant>,
-    #[account(mut)]
     pub authority: Signer<'info>,
 }

--- a/programs/protocol_event/src/instructions/create_participant.rs
+++ b/programs/protocol_event/src/instructions/create_participant.rs
@@ -53,6 +53,7 @@ fn initialize_participant(
 
     participant.category = *category;
     participant.payer = *payer;
+    participant.authority = *payer;
 
     participant.participant_type = participant_type;
     participant.code = code;

--- a/programs/protocol_event/src/instructions/mod.rs
+++ b/programs/protocol_event/src/instructions/mod.rs
@@ -3,9 +3,11 @@ pub mod create_grouping;
 pub mod create_participant;
 pub mod update_event;
 pub mod update_grouping;
+pub mod update_participant;
 
 pub use create_event::*;
 pub use create_grouping::*;
 pub use create_participant::*;
 pub use update_event::*;
 pub use update_grouping::*;
+pub use update_participant::*;

--- a/programs/protocol_event/src/instructions/update_participant.rs
+++ b/programs/protocol_event/src/instructions/update_participant.rs
@@ -1,0 +1,74 @@
+use crate::error::EventError;
+use crate::state::participant::Participant;
+use anchor_lang::prelude::*;
+
+pub fn update_code(participant: &mut Participant, code: String) -> Result<()> {
+    require!(
+        code.len() <= Participant::MAX_CODE_LENGTH,
+        EventError::MaxStringLengthExceeded,
+    );
+
+    participant.code = code;
+
+    Ok(())
+}
+
+pub fn update_name(participant: &mut Participant, name: String) -> Result<()> {
+    require!(
+        name.len() <= Participant::MAX_NAME_LENGTH,
+        EventError::MaxStringLengthExceeded,
+    );
+
+    participant.name = name;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::participant::ParticipantType;
+
+    #[test]
+    fn test_update_code() {
+        let mut participant = &mut participant();
+        let result = update_code(&mut participant, "new code".to_string());
+        assert!(result.is_ok());
+        assert_eq!(participant.code, "new code".to_string());
+    }
+
+    #[test]
+    fn test_update_code_code_exceeds_limit() {
+        let result = update_code(&mut participant(), "012345678".to_string());
+        assert_eq!(result, Err(error!(EventError::MaxStringLengthExceeded)));
+    }
+
+    #[test]
+    fn test_update_name() {
+        let mut participant = &mut participant();
+        let result = update_code(&mut participant, "new name".to_string());
+        assert!(result.is_ok());
+        assert_eq!(participant.code, "new name".to_string());
+    }
+
+    #[test]
+    fn test_update_name_name_exceeds_limit() {
+        let result = update_code(
+            &mut participant(),
+            "012345678901234567890123456789012345678901234567890".to_string(),
+        );
+        assert_eq!(result, Err(error!(EventError::MaxStringLengthExceeded)));
+    }
+
+    fn participant() -> Participant {
+        Participant {
+            code: "code".to_string(),
+            name: "name".to_string(),
+            id: 1,
+            participant_type: ParticipantType::Team,
+            category: Pubkey::new_from_array([0; 32]),
+            payer: Pubkey::new_from_array([0; 32]),
+            authority: Default::default(),
+        }
+    }
+}

--- a/programs/protocol_event/src/instructions/update_participant.rs
+++ b/programs/protocol_event/src/instructions/update_participant.rs
@@ -46,14 +46,14 @@ mod tests {
     #[test]
     fn test_update_name() {
         let mut participant = &mut participant();
-        let result = update_code(&mut participant, "new name".to_string());
+        let result = update_name(&mut participant, "new name".to_string());
         assert!(result.is_ok());
-        assert_eq!(participant.code, "new name".to_string());
+        assert_eq!(participant.name, "new name".to_string());
     }
 
     #[test]
     fn test_update_name_name_exceeds_limit() {
-        let result = update_code(
+        let result = update_name(
             &mut participant(),
             "012345678901234567890123456789012345678901234567890".to_string(),
         );

--- a/programs/protocol_event/src/lib.rs
+++ b/programs/protocol_event/src/lib.rs
@@ -164,4 +164,18 @@ pub mod protocol_event {
             ctx.accounts.category.participant_count,
         )
     }
+
+    pub fn update_participant_name(
+        ctx: Context<UpdateParticipant>,
+        updated_name: String,
+    ) -> Result<()> {
+        instructions::update_participant::update_name(&mut ctx.accounts.participant, updated_name)
+    }
+
+    pub fn update_participant_code(
+        ctx: Context<UpdateParticipant>,
+        updated_code: String,
+    ) -> Result<()> {
+        instructions::update_participant::update_code(&mut ctx.accounts.participant, updated_code)
+    }
 }

--- a/programs/protocol_event/src/state/participant.rs
+++ b/programs/protocol_event/src/state/participant.rs
@@ -12,6 +12,7 @@ pub struct Participant {
     pub code: String,
     pub id: u16,
 
+    pub authority: Pubkey,
     pub payer: Pubkey,
 }
 
@@ -26,7 +27,7 @@ impl Participant {
     pub const MAX_NAME_LENGTH: usize = 50;
 
     pub const SIZE: usize = DISCRIMINATOR_SIZE
-        + PUB_KEY_SIZE * 2
+        + PUB_KEY_SIZE * 3
         + ENUM_SIZE
         + vec_size(CHAR_SIZE, Participant::MAX_NAME_LENGTH)
         + vec_size(CHAR_SIZE, Participant::MAX_CODE_LENGTH)

--- a/tests/participant/update_participant.ts
+++ b/tests/participant/update_participant.ts
@@ -1,0 +1,59 @@
+import * as anchor from "@coral-xyz/anchor";
+import { createIndividualParticipant } from "../util/test_util";
+import { footballCategoryPda } from "../util/pda";
+import assert from "assert";
+
+describe("Update Participants", () => {
+  it("Update participant - Success", async () => {
+    const program = anchor.workspace.ProtocolEvent;
+
+    const code = "EWANM";
+    const name = "Ewan Mcgregor";
+    const participantPk = await createIndividualParticipant(
+      program,
+      footballCategoryPda(),
+      code,
+      name,
+    );
+
+    const participant = await program.account.participant.fetch(participantPk);
+    assert.equal(code, participant.code);
+    assert.equal(name, participant.name);
+
+    const updatedName = "Mcgregor Ewan";
+    await program.methods
+      .updateParticipantName(updatedName)
+      .accounts({
+        participant: participantPk,
+        authority: program.provider.publicKey,
+      })
+      .rpc()
+      .catch((e) => {
+        console.error(e);
+        throw e;
+      });
+
+    const participantNameUpdate = await program.account.participant.fetch(
+      participantPk,
+    );
+    assert.equal(updatedName, participantNameUpdate.name);
+
+    const updatedCode = "MNAWE";
+    await program.methods
+      .updateParticipantCode(updatedCode)
+      .accounts({
+        participant: participantPk,
+        authority: program.provider.publicKey,
+      })
+      .rpc()
+      .catch((e) => {
+        console.error(e);
+        throw e;
+      });
+
+    const participantCodeUpdate = await program.account.participant.fetch(
+      participantPk,
+    );
+    assert.equal(updatedCode, participantCodeUpdate.code);
+  });
+});


### PR DESCRIPTION
Add a distinct authority field on `Participant` 

Instructions to:
- Update participant code
- Update participant name