### PR TITLE
feat: update grouping accounts

### DIFF
--- a/programs/protocol_event/src/context.rs
+++ b/programs/protocol_event/src/context.rs
@@ -47,7 +47,6 @@ pub struct UpdateEvent<'info> {
     pub event: Account<'info, Event>,
     pub category: Account<'info, Category>,
 
-    #[account(mut)]
     pub authority: Signer<'info>,
 }
 
@@ -76,7 +75,6 @@ pub struct CreateCategory<'info> {
 pub struct UpdateCategory<'info> {
     #[account(mut, has_one = authority)]
     pub category: Account<'info, Category>,
-    #[account(mut)]
     pub authority: Signer<'info>,
 }
 
@@ -107,7 +105,6 @@ pub struct CreateEventGroup<'info> {
 pub struct UpdateEventGroup<'info> {
     #[account(mut, has_one = authority)]
     pub event_group: Account<'info, EventGroup>,
-    #[account(mut)]
     pub authority: Signer<'info>,
 }
 

--- a/programs/protocol_event/src/context.rs
+++ b/programs/protocol_event/src/context.rs
@@ -73,6 +73,14 @@ pub struct CreateCategory<'info> {
 }
 
 #[derive(Accounts)]
+pub struct UpdateCategory<'info> {
+    #[account(mut, has_one = authority)]
+    pub category: Account<'info, Category>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
+}
+
+#[derive(Accounts)]
 #[instruction(code: String)]
 pub struct CreateEventGroup<'info> {
     #[account(
@@ -93,6 +101,14 @@ pub struct CreateEventGroup<'info> {
     pub payer: Signer<'info>,
     #[account(address = system_program::ID)]
     pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateEventGroup<'info> {
+    #[account(mut, has_one = authority)]
+    pub event_group: Account<'info, EventGroup>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
 }
 
 #[derive(Accounts)]

--- a/programs/protocol_event/src/instructions/create_grouping.rs
+++ b/programs/protocol_event/src/instructions/create_grouping.rs
@@ -43,6 +43,7 @@ pub fn create_event_group(
 
     event_group.category = category;
     event_group.payer = payer;
+    event_group.authority = payer;
     event_group.code = code;
     event_group.name = name;
 

--- a/programs/protocol_event/src/instructions/create_grouping.rs
+++ b/programs/protocol_event/src/instructions/create_grouping.rs
@@ -12,6 +12,7 @@ pub fn create_category(
     validate_category(&code, &name)?;
 
     category.payer = payer;
+    category.authority = payer;
     category.code = code;
     category.name = name;
     category.participant_count = 0;
@@ -76,6 +77,7 @@ mod tests {
             code: "".to_string(),
             name: "".to_string(),
             participant_count: 0,
+            authority: Default::default(),
             payer: Default::default(),
         };
 
@@ -87,6 +89,7 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(new_category.payer, payer);
+        assert_eq!(new_category.authority, payer);
         assert_eq!(new_category.code, code);
         assert_eq!(new_category.name, name);
         assert_eq!(new_category.participant_count, 0);
@@ -115,6 +118,7 @@ mod tests {
             category: Default::default(),
             code: "".to_string(),
             name: "".to_string(),
+            authority: Default::default(),
             payer: Default::default(),
         };
 
@@ -134,6 +138,7 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(new_event_group.category, category);
         assert_eq!(new_event_group.payer, payer);
+        assert_eq!(new_event_group.authority, payer);
         assert_eq!(new_event_group.code, code);
         assert_eq!(new_event_group.name, name);
     }

--- a/programs/protocol_event/src/instructions/update_grouping.rs
+++ b/programs/protocol_event/src/instructions/update_grouping.rs
@@ -1,9 +1,54 @@
 use anchor_lang::prelude::*;
 
+use crate::error::EventError;
 use crate::state::category::Category;
+use crate::state::event_group::EventGroup;
 
 pub fn increment_category_participant_count(category: &mut Category) -> Result<()> {
     category.participant_count = category.participant_count.checked_add(1).unwrap();
 
     Ok(())
+}
+
+pub fn update_category_name(category: &mut Category, updated_name: String) -> Result<()> {
+    require!(
+        updated_name.len() <= EventGroup::MAX_NAME_LENGTH,
+        EventError::MaxStringLengthExceeded,
+    );
+
+    category.name = updated_name;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_category_name() {
+        let mut category = &mut category();
+        let result = update_category_name(&mut category, "new name".to_string());
+        assert!(result.is_ok());
+        assert_eq!(category.name, "new name".to_string());
+    }
+
+    #[test]
+    fn test_update_name_name_exceeds_limit() {
+        let result = update_category_name(
+            &mut category(),
+            "012345678901234567890123456789012345678901234567890".to_string(),
+        );
+        assert_eq!(result, Err(error!(EventError::MaxStringLengthExceeded)));
+    }
+
+    fn category() -> Category {
+        Category {
+            code: "code".to_string(),
+            name: "name".to_string(),
+            participant_count: 0,
+            authority: Pubkey::new_unique(),
+            payer: Pubkey::new_unique(),
+        }
+    }
 }

--- a/programs/protocol_event/src/instructions/update_grouping.rs
+++ b/programs/protocol_event/src/instructions/update_grouping.rs
@@ -21,6 +21,17 @@ pub fn update_category_name(category: &mut Category, updated_name: String) -> Re
     Ok(())
 }
 
+pub fn update_event_group_name(event_group: &mut EventGroup, updated_name: String) -> Result<()> {
+    require!(
+        updated_name.len() <= EventGroup::MAX_NAME_LENGTH,
+        EventError::MaxStringLengthExceeded,
+    );
+
+    event_group.name = updated_name;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -34,7 +45,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_name_name_exceeds_limit() {
+    fn test_update_category_name_name_exceeds_limit() {
         let result = update_category_name(
             &mut category(),
             "012345678901234567890123456789012345678901234567890".to_string(),
@@ -47,6 +58,33 @@ mod tests {
             code: "code".to_string(),
             name: "name".to_string(),
             participant_count: 0,
+            authority: Pubkey::new_unique(),
+            payer: Pubkey::new_unique(),
+        }
+    }
+
+    #[test]
+    fn test_update_event_group_name() {
+        let event_group = &mut event_group();
+        let result = update_event_group_name(event_group, "new name".to_string());
+        assert!(result.is_ok());
+        assert_eq!(event_group.name, "new name".to_string());
+    }
+
+    #[test]
+    fn test_update_event_group_name_name_exceeds_limit() {
+        let result = update_event_group_name(
+            &mut event_group(),
+            "012345678901234567890123456789012345678901234567890".to_string(),
+        );
+        assert_eq!(result, Err(error!(EventError::MaxStringLengthExceeded)));
+    }
+
+    fn event_group() -> EventGroup {
+        EventGroup {
+            category: Default::default(),
+            code: "code".to_string(),
+            name: "name".to_string(),
             authority: Pubkey::new_unique(),
             payer: Pubkey::new_unique(),
         }

--- a/programs/protocol_event/src/lib.rs
+++ b/programs/protocol_event/src/lib.rs
@@ -113,6 +113,13 @@ pub mod protocol_event {
         )
     }
 
+    pub fn update_category_name(ctx: Context<UpdateCategory>, updated_name: String) -> Result<()> {
+        instructions::update_grouping::update_category_name(
+            &mut ctx.accounts.category,
+            updated_name,
+        )
+    }
+
     pub fn create_event_group(
         ctx: Context<CreateEventGroup>,
         code: String,
@@ -126,6 +133,13 @@ pub mod protocol_event {
             name,
         )
     }
+
+    // pub fn update_event_group_name(ctx: Context<UpdateEventGroup>, updated_name: String) -> Result<()> {
+    //     instructions::update_grouping::update_category_name(
+    //         &mut ctx.accounts.event_group,
+    //         updated_name,
+    //     )
+    // }
 
     // Participant management instructions
 

--- a/programs/protocol_event/src/lib.rs
+++ b/programs/protocol_event/src/lib.rs
@@ -134,12 +134,15 @@ pub mod protocol_event {
         )
     }
 
-    // pub fn update_event_group_name(ctx: Context<UpdateEventGroup>, updated_name: String) -> Result<()> {
-    //     instructions::update_grouping::update_category_name(
-    //         &mut ctx.accounts.event_group,
-    //         updated_name,
-    //     )
-    // }
+    pub fn update_event_group_name(
+        ctx: Context<UpdateEventGroup>,
+        updated_name: String,
+    ) -> Result<()> {
+        instructions::update_grouping::update_event_group_name(
+            &mut ctx.accounts.event_group,
+            updated_name,
+        )
+    }
 
     // Participant management instructions
 

--- a/programs/protocol_event/src/state/category.rs
+++ b/programs/protocol_event/src/state/category.rs
@@ -6,6 +6,7 @@ pub struct Category {
     pub code: String,
     pub name: String,
     pub participant_count: u16,
+    pub authority: Pubkey,
     pub payer: Pubkey,
 }
 
@@ -13,7 +14,7 @@ impl Category {
     pub const MAX_CODE_LENGTH: usize = 8;
     pub const MAX_NAME_LENGTH: usize = 50;
 
-    pub const SIZE: usize = PUB_KEY_SIZE
+    pub const SIZE: usize = PUB_KEY_SIZE * 2
         + vec_size(CHAR_SIZE, Category::MAX_CODE_LENGTH)
         + vec_size(CHAR_SIZE, Category::MAX_NAME_LENGTH)
         + U16_SIZE;

--- a/programs/protocol_event/src/state/event_group.rs
+++ b/programs/protocol_event/src/state/event_group.rs
@@ -6,6 +6,7 @@ pub struct EventGroup {
     pub category: Pubkey,
     pub code: String,
     pub name: String,
+    pub authority: Pubkey,
     pub payer: Pubkey,
 }
 
@@ -13,7 +14,7 @@ impl EventGroup {
     pub const MAX_CODE_LENGTH: usize = 8;
     pub const MAX_NAME_LENGTH: usize = 50;
 
-    pub const SIZE: usize = PUB_KEY_SIZE * 2
+    pub const SIZE: usize = PUB_KEY_SIZE * 3
         + vec_size(CHAR_SIZE, EventGroup::MAX_CODE_LENGTH)
         + vec_size(CHAR_SIZE, EventGroup::MAX_NAME_LENGTH);
 }

--- a/tests/grouping/update_grouping.ts
+++ b/tests/grouping/update_grouping.ts
@@ -1,0 +1,68 @@
+import * as anchor from "@coral-xyz/anchor";
+import { createCategory, createEventGroup } from "../util/test_util";
+import assert from "assert";
+
+describe("Update Grouping Accounts", () => {
+  it("Update category", async () => {
+    const program = anchor.workspace.ProtocolEvent;
+
+    const code = "BT";
+    const name = "Bean Throwing";
+    const categoryPk = await createCategory(program, code, name);
+
+    const category = await program.account.category.fetch(categoryPk);
+    assert.equal(code, category.code);
+    assert.equal(name, category.name);
+
+    const updatedName = "Bean Throwing UK";
+    await program.methods
+      .updateCategoryName(updatedName)
+      .accounts({
+        category: categoryPk,
+        authority: program.provider.publicKey,
+      })
+      .rpc();
+
+    const categoryAfterUpdate = await program.account.category.fetch(
+      categoryPk,
+    );
+    assert.equal(updatedName, categoryAfterUpdate.name);
+  });
+
+  it("Update event group", async () => {
+    const program = anchor.workspace.ProtocolEvent;
+
+    const categoryPk = await createCategory(
+      program,
+      "FLCC",
+      "Four-Leaf Clover Collecting",
+    );
+
+    const code = "PFLCC";
+    const name = "Premier Four-Leaf Clover Collecting";
+    const eventGroupPk = await createEventGroup(
+      program,
+      categoryPk,
+      code,
+      name,
+    );
+
+    const eventGroup = await program.account.eventGroup.fetch(eventGroupPk);
+    assert.equal(code, eventGroup.code);
+    assert.equal(name, eventGroup.name);
+
+    const updatedName = "Four-Leaf Clover and Buttercup Collecting UK";
+    await program.methods
+      .updateEventGroupName(updatedName)
+      .accounts({
+        eventGroup: eventGroupPk,
+        authority: program.provider.publicKey,
+      })
+      .rpc();
+
+    const eventGroupAfterUpdate = await program.account.eventGroup.fetch(
+      eventGroupPk,
+    );
+    assert.equal(updatedName, eventGroupAfterUpdate.name);
+  });
+});


### PR DESCRIPTION
Add instructions to:
* Update Category name
* Update Event Group name

Note that `code` is immutable for both of these accounts as it is used as a seed