### PR TITLE
feat: add new Classification parent grouping

### DIFF
--- a/client/accounts/Classification.ts
+++ b/client/accounts/Classification.ts
@@ -4,51 +4,41 @@ import * as borsh from "@coral-xyz/borsh" // eslint-disable-line @typescript-esl
 import * as types from "../types" // eslint-disable-line @typescript-eslint/no-unused-vars
 import { PROGRAM_ID } from "../programId"
 
-export interface CategoryFields {
+export interface ClassificationFields {
   authority: PublicKey
-  classification: PublicKey
   code: string
   name: string
-  participantCount: number
   payer: PublicKey
 }
 
-export interface CategoryJSON {
+export interface ClassificationJSON {
   authority: string
-  classification: string
   code: string
   name: string
-  participantCount: number
   payer: string
 }
 
-export class Category {
+export class Classification {
   readonly authority: PublicKey
-  readonly classification: PublicKey
   readonly code: string
   readonly name: string
-  readonly participantCount: number
   readonly payer: PublicKey
 
   static readonly discriminator = Buffer.from([
-    242, 35, 245, 232, 221, 227, 98, 52,
+    229, 1, 103, 182, 216, 191, 58, 250,
   ])
 
   static readonly layout = borsh.struct([
     borsh.publicKey("authority"),
-    borsh.publicKey("classification"),
     borsh.str("code"),
     borsh.str("name"),
-    borsh.u16("participantCount"),
     borsh.publicKey("payer"),
   ])
 
-  constructor(fields: CategoryFields) {
+  constructor(fields: ClassificationFields) {
     this.authority = fields.authority
-    this.classification = fields.classification
     this.code = fields.code
     this.name = fields.name
-    this.participantCount = fields.participantCount
     this.payer = fields.payer
   }
 
@@ -56,7 +46,7 @@ export class Category {
     c: Connection,
     address: PublicKey,
     programId: PublicKey = PROGRAM_ID
-  ): Promise<Category | null> {
+  ): Promise<Classification | null> {
     const info = await c.getAccountInfo(address)
 
     if (info === null) {
@@ -73,7 +63,7 @@ export class Category {
     c: Connection,
     addresses: PublicKey[],
     programId: PublicKey = PROGRAM_ID
-  ): Promise<Array<Category | null>> {
+  ): Promise<Array<Classification | null>> {
     const infos = await c.getMultipleAccountsInfo(addresses)
 
     return infos.map((info) => {
@@ -88,41 +78,35 @@ export class Category {
     })
   }
 
-  static decode(data: Buffer): Category {
-    if (!data.slice(0, 8).equals(Category.discriminator)) {
+  static decode(data: Buffer): Classification {
+    if (!data.slice(0, 8).equals(Classification.discriminator)) {
       throw new Error("invalid account discriminator")
     }
 
-    const dec = Category.layout.decode(data.slice(8))
+    const dec = Classification.layout.decode(data.slice(8))
 
-    return new Category({
+    return new Classification({
       authority: dec.authority,
-      classification: dec.classification,
       code: dec.code,
       name: dec.name,
-      participantCount: dec.participantCount,
       payer: dec.payer,
     })
   }
 
-  toJSON(): CategoryJSON {
+  toJSON(): ClassificationJSON {
     return {
       authority: this.authority.toString(),
-      classification: this.classification.toString(),
       code: this.code,
       name: this.name,
-      participantCount: this.participantCount,
       payer: this.payer.toString(),
     }
   }
 
-  static fromJSON(obj: CategoryJSON): Category {
-    return new Category({
+  static fromJSON(obj: ClassificationJSON): Classification {
+    return new Classification({
       authority: new PublicKey(obj.authority),
-      classification: new PublicKey(obj.classification),
       code: obj.code,
       name: obj.name,
-      participantCount: obj.participantCount,
       payer: new PublicKey(obj.payer),
     })
   }

--- a/client/accounts/index.ts
+++ b/client/accounts/index.ts
@@ -1,5 +1,7 @@
 export { Category } from "./Category"
 export type { CategoryFields, CategoryJSON } from "./Category"
+export { Classification } from "./Classification"
+export type { ClassificationFields, ClassificationJSON } from "./Classification"
 export { EventGroup } from "./EventGroup"
 export type { EventGroupFields, EventGroupJSON } from "./EventGroup"
 export { Event } from "./Event"

--- a/client/instructions/closeClassification.ts
+++ b/client/instructions/closeClassification.ts
@@ -1,0 +1,26 @@
+import { TransactionInstruction, PublicKey, AccountMeta } from "@solana/web3.js" // eslint-disable-line @typescript-eslint/no-unused-vars
+import BN from "bn.js" // eslint-disable-line @typescript-eslint/no-unused-vars
+import * as borsh from "@coral-xyz/borsh" // eslint-disable-line @typescript-eslint/no-unused-vars
+import * as types from "../types" // eslint-disable-line @typescript-eslint/no-unused-vars
+import { PROGRAM_ID } from "../programId"
+
+export interface CloseClassificationAccounts {
+  category: PublicKey
+  authority: PublicKey
+  payer: PublicKey
+}
+
+export function closeClassification(
+  accounts: CloseClassificationAccounts,
+  programId: PublicKey = PROGRAM_ID
+) {
+  const keys: Array<AccountMeta> = [
+    { pubkey: accounts.category, isSigner: false, isWritable: true },
+    { pubkey: accounts.authority, isSigner: true, isWritable: false },
+    { pubkey: accounts.payer, isSigner: false, isWritable: true },
+  ]
+  const identifier = Buffer.from([3, 93, 204, 31, 46, 199, 87, 46])
+  const data = identifier
+  const ix = new TransactionInstruction({ keys, programId, data })
+  return ix
+}

--- a/client/instructions/createClassification.ts
+++ b/client/instructions/createClassification.ts
@@ -4,13 +4,12 @@ import * as borsh from "@coral-xyz/borsh" // eslint-disable-line @typescript-esl
 import * as types from "../types" // eslint-disable-line @typescript-eslint/no-unused-vars
 import { PROGRAM_ID } from "../programId"
 
-export interface CreateCategoryArgs {
+export interface CreateClassificationArgs {
   code: string
   name: string
 }
 
-export interface CreateCategoryAccounts {
-  category: PublicKey
+export interface CreateClassificationAccounts {
   classification: PublicKey
   payer: PublicKey
   systemProgram: PublicKey
@@ -18,18 +17,17 @@ export interface CreateCategoryAccounts {
 
 export const layout = borsh.struct([borsh.str("code"), borsh.str("name")])
 
-export function createCategory(
-  args: CreateCategoryArgs,
-  accounts: CreateCategoryAccounts,
+export function createClassification(
+  args: CreateClassificationArgs,
+  accounts: CreateClassificationAccounts,
   programId: PublicKey = PROGRAM_ID
 ) {
   const keys: Array<AccountMeta> = [
-    { pubkey: accounts.category, isSigner: false, isWritable: true },
-    { pubkey: accounts.classification, isSigner: false, isWritable: false },
+    { pubkey: accounts.classification, isSigner: false, isWritable: true },
     { pubkey: accounts.payer, isSigner: true, isWritable: true },
     { pubkey: accounts.systemProgram, isSigner: false, isWritable: false },
   ]
-  const identifier = Buffer.from([220, 242, 238, 47, 228, 219, 223, 230])
+  const identifier = Buffer.from([195, 104, 62, 103, 225, 157, 209, 47])
   const buffer = Buffer.alloc(1000)
   const len = layout.encode(
     {

--- a/client/instructions/index.ts
+++ b/client/instructions/index.ts
@@ -37,6 +37,16 @@ export type {
   UpdateEventNameArgs,
   UpdateEventNameAccounts,
 } from "./updateEventName"
+export { createClassification } from "./createClassification"
+export type {
+  CreateClassificationArgs,
+  CreateClassificationAccounts,
+} from "./createClassification"
+export { updateClassificationName } from "./updateClassificationName"
+export type {
+  UpdateClassificationNameArgs,
+  UpdateClassificationNameAccounts,
+} from "./updateClassificationName"
 export { createCategory } from "./createCategory"
 export type {
   CreateCategoryArgs,
@@ -83,6 +93,8 @@ export { deactivateParticipant } from "./deactivateParticipant"
 export type { DeactivateParticipantAccounts } from "./deactivateParticipant"
 export { closeEvent } from "./closeEvent"
 export type { CloseEventAccounts } from "./closeEvent"
+export { closeClassification } from "./closeClassification"
+export type { CloseClassificationAccounts } from "./closeClassification"
 export { closeEventGroup } from "./closeEventGroup"
 export type { CloseEventGroupAccounts } from "./closeEventGroup"
 export { closeCategory } from "./closeCategory"

--- a/client/instructions/updateClassificationName.ts
+++ b/client/instructions/updateClassificationName.ts
@@ -4,37 +4,31 @@ import * as borsh from "@coral-xyz/borsh" // eslint-disable-line @typescript-esl
 import * as types from "../types" // eslint-disable-line @typescript-eslint/no-unused-vars
 import { PROGRAM_ID } from "../programId"
 
-export interface CreateCategoryArgs {
-  code: string
-  name: string
+export interface UpdateClassificationNameArgs {
+  updatedName: string
 }
 
-export interface CreateCategoryAccounts {
-  category: PublicKey
+export interface UpdateClassificationNameAccounts {
   classification: PublicKey
-  payer: PublicKey
-  systemProgram: PublicKey
+  authority: PublicKey
 }
 
-export const layout = borsh.struct([borsh.str("code"), borsh.str("name")])
+export const layout = borsh.struct([borsh.str("updatedName")])
 
-export function createCategory(
-  args: CreateCategoryArgs,
-  accounts: CreateCategoryAccounts,
+export function updateClassificationName(
+  args: UpdateClassificationNameArgs,
+  accounts: UpdateClassificationNameAccounts,
   programId: PublicKey = PROGRAM_ID
 ) {
   const keys: Array<AccountMeta> = [
-    { pubkey: accounts.category, isSigner: false, isWritable: true },
-    { pubkey: accounts.classification, isSigner: false, isWritable: false },
-    { pubkey: accounts.payer, isSigner: true, isWritable: true },
-    { pubkey: accounts.systemProgram, isSigner: false, isWritable: false },
+    { pubkey: accounts.classification, isSigner: false, isWritable: true },
+    { pubkey: accounts.authority, isSigner: true, isWritable: false },
   ]
-  const identifier = Buffer.from([220, 242, 238, 47, 228, 219, 223, 230])
+  const identifier = Buffer.from([78, 156, 88, 38, 217, 65, 218, 15])
   const buffer = Buffer.alloc(1000)
   const len = layout.encode(
     {
-      code: args.code,
-      name: args.name,
+      updatedName: args.updatedName,
     },
     buffer
   )

--- a/programs/protocol_event/src/context.rs
+++ b/programs/protocol_event/src/context.rs
@@ -1,6 +1,7 @@
 use crate::error::EventError;
 use crate::instructions::CreateEventInfo;
 use crate::state::category::Category;
+use crate::state::classification::Classification;
 use crate::state::event_group::EventGroup;
 use crate::state::participant::Participant;
 use crate::Event;
@@ -53,18 +54,48 @@ pub struct UpdateEvent<'info> {
 
 #[derive(Accounts)]
 #[instruction(code: String)]
+pub struct CreateClassification<'info> {
+    #[account(
+        init,
+        payer = payer,
+        seeds = [
+        b"classification".as_ref(),
+        code.as_ref(),
+    ],
+    bump,
+    space = Classification::SIZE
+    )]
+    pub classification: Account<'info, Classification>,
+
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(address = system_program::ID)]
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateClassification<'info> {
+    #[account(mut, has_one = authority)]
+    pub classification: Account<'info, Classification>,
+    pub authority: Signer<'info>,
+}
+
+#[derive(Accounts)]
+#[instruction(code: String)]
 pub struct CreateCategory<'info> {
     #[account(
         init,
         payer = payer,
         seeds = [
             b"category".as_ref(),
+            classification.key().as_ref(),
             code.as_ref(),
         ],
         bump,
         space = Category::SIZE
     )]
     pub category: Account<'info, Category>,
+    pub classification: Account<'info, Classification>,
 
     #[account(mut)]
     pub payer: Signer<'info>,
@@ -195,6 +226,20 @@ pub struct CloseParticipant<'info> {
         close = payer,
     )]
     pub participant: Account<'info, Participant>,
+    pub authority: Signer<'info>,
+    #[account(mut)]
+    pub payer: SystemAccount<'info>,
+}
+
+#[derive(Accounts)]
+pub struct CloseClassification<'info> {
+    #[account(
+        mut,
+        has_one = authority,
+        has_one = payer,
+        close = payer,
+    )]
+    pub classification: Account<'info, Classification>,
     pub authority: Signer<'info>,
     #[account(mut)]
     pub payer: SystemAccount<'info>,

--- a/programs/protocol_event/src/context.rs
+++ b/programs/protocol_event/src/context.rs
@@ -61,9 +61,9 @@ pub struct CreateClassification<'info> {
         seeds = [
         b"classification".as_ref(),
         code.as_ref(),
-    ],
-    bump,
-    space = Classification::SIZE
+        ],
+        bump,
+        space = Classification::SIZE
     )]
     pub classification: Account<'info, Classification>,
 

--- a/programs/protocol_event/src/instructions/update_grouping.rs
+++ b/programs/protocol_event/src/instructions/update_grouping.rs
@@ -2,10 +2,25 @@ use anchor_lang::prelude::*;
 
 use crate::error::EventError;
 use crate::state::category::Category;
+use crate::state::classification::Classification;
 use crate::state::event_group::EventGroup;
 
 pub fn increment_category_participant_count(category: &mut Category) -> Result<()> {
     category.participant_count = category.participant_count.checked_add(1).unwrap();
+
+    Ok(())
+}
+
+pub fn update_classification_name(
+    classification: &mut Classification,
+    updated_name: String,
+) -> Result<()> {
+    require!(
+        updated_name.len() <= EventGroup::MAX_NAME_LENGTH,
+        EventError::MaxStringLengthExceeded,
+    );
+
+    classification.name = updated_name;
 
     Ok(())
 }
@@ -60,6 +75,7 @@ mod tests {
             participant_count: 0,
             authority: Pubkey::new_unique(),
             payer: Pubkey::new_unique(),
+            classification: Default::default(),
         }
     }
 

--- a/programs/protocol_event/src/lib.rs
+++ b/programs/protocol_event/src/lib.rs
@@ -104,9 +104,33 @@ pub mod protocol_event {
 
     // Grouping management instructions
 
+    pub fn create_classification(
+        ctx: Context<CreateClassification>,
+        code: String,
+        name: String,
+    ) -> Result<()> {
+        instructions::create_grouping::create_classification(
+            &mut ctx.accounts.classification,
+            ctx.accounts.payer.key(),
+            code,
+            name,
+        )
+    }
+
+    pub fn update_classification_name(
+        ctx: Context<UpdateClassification>,
+        updated_name: String,
+    ) -> Result<()> {
+        instructions::update_grouping::update_classification_name(
+            &mut ctx.accounts.classification,
+            updated_name,
+        )
+    }
+
     pub fn create_category(ctx: Context<CreateCategory>, code: String, name: String) -> Result<()> {
         instructions::create_grouping::create_category(
             &mut ctx.accounts.category,
+            ctx.accounts.classification.key(),
             ctx.accounts.payer.key(),
             code,
             name,
@@ -207,6 +231,10 @@ pub mod protocol_event {
     // close accounts
 
     pub fn close_event(_ctx: Context<CloseEvent>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn close_classification(_ctx: Context<CloseCategory>) -> Result<()> {
         Ok(())
     }
 

--- a/programs/protocol_event/src/state/category.rs
+++ b/programs/protocol_event/src/state/category.rs
@@ -4,6 +4,7 @@ use anchor_lang::prelude::*;
 #[account]
 pub struct Category {
     pub authority: Pubkey,
+    pub classification: Pubkey,
     pub code: String,
     pub name: String,
     pub participant_count: u16, // current number of Participant accounts created for Category
@@ -14,7 +15,7 @@ impl Category {
     pub const MAX_CODE_LENGTH: usize = 8;
     pub const MAX_NAME_LENGTH: usize = 50;
 
-    pub const SIZE: usize = PUB_KEY_SIZE * 2
+    pub const SIZE: usize = PUB_KEY_SIZE * 3
         + vec_size(CHAR_SIZE, Category::MAX_CODE_LENGTH)
         + vec_size(CHAR_SIZE, Category::MAX_NAME_LENGTH)
         + U16_SIZE;

--- a/programs/protocol_event/src/state/classification.rs
+++ b/programs/protocol_event/src/state/classification.rs
@@ -1,0 +1,19 @@
+use crate::state::type_size::{vec_size, CHAR_SIZE, PUB_KEY_SIZE};
+use anchor_lang::prelude::*;
+
+#[account]
+pub struct Classification {
+    pub authority: Pubkey,
+    pub code: String,
+    pub name: String,
+    pub payer: Pubkey,
+}
+
+impl Classification {
+    pub const MAX_CODE_LENGTH: usize = 8;
+    pub const MAX_NAME_LENGTH: usize = 50;
+
+    pub const SIZE: usize = PUB_KEY_SIZE * 2
+        + vec_size(CHAR_SIZE, Classification::MAX_CODE_LENGTH)
+        + vec_size(CHAR_SIZE, Classification::MAX_NAME_LENGTH);
+}

--- a/programs/protocol_event/src/state/mod.rs
+++ b/programs/protocol_event/src/state/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod category;
+pub(crate) mod classification;
 pub(crate) mod event;
 pub(crate) mod event_group;
 pub(crate) mod participant;

--- a/tests/client/query.ts
+++ b/tests/client/query.ts
@@ -10,7 +10,11 @@ import {
   sendTransaction,
 } from "../util/test_util";
 import { CreateEventInfo } from "../util/constants";
-import { eplEventGroupPda, footballCategoryPda } from "../util/pda";
+import {
+  eplEventGroupPda,
+  footballCategoryPda,
+  sportClassificationPda,
+} from "../util/pda";
 import { Events } from "../../client/queries";
 import assert from "assert";
 import {
@@ -165,7 +169,12 @@ describe("Test Client Queries", () => {
     const program = anchor.workspace.ProtocolEvent as Program<ProtocolEvent>;
     const connection = program.provider.connection;
 
-    const categoryPk = await createCategory(program, "C1", "Test Category 1");
+    const categoryPk = await createCategory(
+      program,
+      sportClassificationPda(),
+      "C1",
+      "Test Category 1",
+    );
 
     const allCategories = await Categories.categoryQuery(connection).fetch();
 

--- a/tests/close_accounts.ts
+++ b/tests/close_accounts.ts
@@ -10,6 +10,7 @@ import * as anchor from "@coral-xyz/anchor";
 import { BN, Program } from "@coral-xyz/anchor";
 import { ProtocolEvent } from "../target/types/protocol_event";
 import assert from "assert";
+import { sportClassificationPda } from "./util/pda";
 
 describe("Close Accounts", () => {
   it("Success", async () => {
@@ -19,6 +20,7 @@ describe("Close Accounts", () => {
 
     const categoryPk = await createCategory(
       program,
+      sportClassificationPda(),
       "CLOSE",
       "To Close",
       payer,

--- a/tests/grouping/create_grouping.ts
+++ b/tests/grouping/create_grouping.ts
@@ -1,15 +1,43 @@
 import * as anchor from "@coral-xyz/anchor";
-import { createCategory, createEventGroup } from "../util/test_util";
+import {
+  createCategory,
+  createClassification,
+  createEventGroup,
+} from "../util/test_util";
 import assert from "assert";
 import { getAnchorProvider } from "../../admin/util";
+import { sportClassificationPda } from "../util/pda";
 
 describe("Create Grouping Accounts", () => {
+  it("Create Classification - Success", async () => {
+    const program = anchor.workspace.ProtocolEvent;
+
+    const code = "POLITICS";
+    const name = "Politics";
+    const classificationPk = await createClassification(program, code, name);
+
+    const classification = await program.account.classification.fetch(
+      classificationPk,
+    );
+    assert.equal(code, classification.code);
+    assert.equal(name, classification.name);
+    assert.equal(
+      getAnchorProvider().publicKey.toBase58(),
+      classification.payer.toBase58(),
+    );
+  });
+
   it("Create Category - Success", async () => {
     const program = anchor.workspace.ProtocolEvent;
 
     const code = "SC";
     const name = "Code Collecting";
-    const categoryPk = await createCategory(program, code, name);
+    const categoryPk = await createCategory(
+      program,
+      sportClassificationPda(),
+      code,
+      name,
+    );
 
     const category = await program.account.category.fetch(categoryPk);
     assert.equal(code, category.code);
@@ -26,6 +54,7 @@ describe("Create Grouping Accounts", () => {
 
     const categoryPk = await createCategory(
       program,
+      sportClassificationPda(),
       "MUSH",
       "Mushroom Stomping",
     );

--- a/tests/grouping/update_grouping.ts
+++ b/tests/grouping/update_grouping.ts
@@ -1,14 +1,51 @@
 import * as anchor from "@coral-xyz/anchor";
-import { createCategory, createEventGroup } from "../util/test_util";
+import {
+  createCategory,
+  createClassification,
+  createEventGroup,
+} from "../util/test_util";
 import assert from "assert";
+import { sportClassificationPda } from "../util/pda";
 
 describe("Update Grouping Accounts", () => {
+  it("Update classification", async () => {
+    const program = anchor.workspace.ProtocolEvent;
+
+    const code = "ESPORTS";
+    const name = "Excellent Sports";
+    const classificationPk = await createClassification(program, code, name);
+
+    const classification = await program.account.classification.fetch(
+      classificationPk,
+    );
+    assert.equal(code, classification.code);
+    assert.equal(name, classification.name);
+
+    const updatedName = "Exceptional Sports";
+    await program.methods
+      .updateClassificationName(updatedName)
+      .accounts({
+        classification: classificationPk,
+        authority: program.provider.publicKey,
+      })
+      .rpc();
+
+    const classificiationAfterUpdate =
+      await program.account.classification.fetch(classificationPk);
+    assert.equal(updatedName, classificiationAfterUpdate.name);
+  });
+
   it("Update category", async () => {
     const program = anchor.workspace.ProtocolEvent;
 
     const code = "BT";
     const name = "Bean Throwing";
-    const categoryPk = await createCategory(program, code, name);
+    const categoryPk = await createCategory(
+      program,
+      sportClassificationPda(),
+      code,
+      name,
+    );
 
     const category = await program.account.category.fetch(categoryPk);
     assert.equal(code, category.code);
@@ -34,6 +71,7 @@ describe("Update Grouping Accounts", () => {
 
     const categoryPk = await createCategory(
       program,
+      sportClassificationPda(),
       "FLCC",
       "Four-Leaf Clover Collecting",
     );

--- a/tests/participant/create_participant.ts
+++ b/tests/participant/create_participant.ts
@@ -6,7 +6,11 @@ import {
 } from "../util/test_util";
 import * as anchor from "@coral-xyz/anchor";
 import { Program } from "@coral-xyz/anchor";
-import { findParticipantPda, footballCategoryPda } from "../util/pda";
+import {
+  findParticipantPda,
+  footballCategoryPda,
+  sportClassificationPda,
+} from "../util/pda";
 import assert from "assert";
 import { getAnchorProvider } from "../../admin/util";
 import { SystemProgram } from "@solana/web3.js";
@@ -66,7 +70,12 @@ describe("Create Participants", () => {
   it("Create Multiple Participants - Category participant count and id increments", async () => {
     const program = anchor.workspace.ProtocolEvent;
 
-    const categoryPk = await createCategory(program, "SPORT", "Sportsball 99");
+    const categoryPk = await createCategory(
+      program,
+      sportClassificationPda(),
+      "SPORT",
+      "Sportsball 99",
+    );
 
     const code = "EWANM";
     const participant1Pk = await createIndividualParticipant(
@@ -117,6 +126,7 @@ describe("Create Participants", () => {
 
     const categoryPk = await createCategory(
       program,
+      sportClassificationPda(),
       "CAUTH",
       "CategoryDefaultAuth",
     );

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,6 +2,7 @@ import * as anchor from "@coral-xyz/anchor";
 import { ProtocolEvent } from "../target/types/protocol_event";
 import {
   createCategory,
+  createClassification,
   createEventGroup,
   createIndividualParticipant,
 } from "./util/test_util";
@@ -11,7 +12,20 @@ module.exports = async function (_globalConfig, _projectConfig) {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(provider);
 
-  const categoryPk = await createCategory(program, "FOOTBALL", "Soccer");
+  // create some default grouping accounts
+  const classificationPk = await createClassification(
+    program,
+    "SPORT",
+    "Sport",
+  );
+  const categoryPk = await createCategory(
+    program,
+    classificationPk,
+    "FOOTBALL",
+    "Soccer",
+  );
+  await createEventGroup(program, categoryPk, "EPL", "English Premier League");
+
   // initialize some participants for category
   for (let i = 0; i < 10; i++) {
     await createIndividualParticipant(
@@ -21,5 +35,4 @@ module.exports = async function (_globalConfig, _projectConfig) {
       `Player ${i}`,
     );
   }
-  await createEventGroup(program, categoryPk, "EPL", "English Premier League");
 };

--- a/tests/util/pda.ts
+++ b/tests/util/pda.ts
@@ -10,9 +10,24 @@ export function findEventPda(code: string, program: Program): PublicKey {
   return pda;
 }
 
-export function findCategoryPda(code: string, program: Program): PublicKey {
+export function findClassificationPda(
+  code: string,
+  program: Program,
+): PublicKey {
   const [pda] = PublicKey.findProgramAddressSync(
-    [Buffer.from("category"), Buffer.from(code)],
+    [Buffer.from("classification"), Buffer.from(code)],
+    program.programId,
+  );
+  return pda;
+}
+
+export function findCategoryPda(
+  classification: PublicKey,
+  code: string,
+  program: Program,
+): PublicKey {
+  const [pda] = PublicKey.findProgramAddressSync(
+    [Buffer.from("category"), classification.toBuffer(), Buffer.from(code)],
     program.programId,
   );
   return pda;
@@ -30,9 +45,14 @@ export function findEventGroupPda(
   return pda;
 }
 
+export function sportClassificationPda(): PublicKey {
+  const program: anchor.Program = anchor.workspace.ProtocolEvent;
+  return findClassificationPda("SPORT", program);
+}
+
 export function footballCategoryPda(): PublicKey {
   const program: anchor.Program = anchor.workspace.ProtocolEvent;
-  return findCategoryPda("FOOTBALL", program);
+  return findCategoryPda(sportClassificationPda(), "FOOTBALL", program);
 }
 
 export function eplEventGroupPda(): PublicKey {


### PR DESCRIPTION
Add a new "parent" grouping, `Classification`, which sits above `Category`. This will allow us to group categories together easier, for example:


| Classification  | Category | EventGroup |
| ------------- | ------------- | ------------- |
| SPORT  | FOOTBALL  | EPL  |
| SPORT | BASKETBALL  | NBA  |
| ESPORT  | CSGO  | IEM2023  |
| ESPORT  | LOL  | WORLDS2024  |
| POLITICS  | ELECTIONS  | GENERAL2025  |
| ENTERTAINMENT  | TV_SHOW  | LOVEISLAND2023  |

