### PR TITLE
fix: remaining audit issues

### DIFF
--- a/client/errors/custom.ts
+++ b/client/errors/custom.ts
@@ -3,6 +3,7 @@ export type CustomError =
   | MaxParticipantsExceeded
   | InvalidEventParticipants
   | AuthorityMismatch
+  | InvalidTimestamp
 
 export class MaxStringLengthExceeded extends Error {
   static readonly code = 6000
@@ -48,6 +49,17 @@ export class AuthorityMismatch extends Error {
   }
 }
 
+export class InvalidTimestamp extends Error {
+  static readonly code = 6004
+  readonly code = 6004
+  readonly name = "InvalidTimestamp"
+  readonly msg = "Invalid timestamp"
+
+  constructor(readonly logs?: string[]) {
+    super("6004: Invalid timestamp")
+  }
+}
+
 export function fromCode(code: number, logs?: string[]): CustomError | null {
   switch (code) {
     case 6000:
@@ -58,6 +70,8 @@ export function fromCode(code: number, logs?: string[]): CustomError | null {
       return new InvalidEventParticipants(logs)
     case 6003:
       return new AuthorityMismatch(logs)
+    case 6004:
+      return new InvalidTimestamp(logs)
   }
 
   return null

--- a/programs/protocol_event/src/error.rs
+++ b/programs/protocol_event/src/error.rs
@@ -10,4 +10,6 @@ pub enum EventError {
     InvalidEventParticipants,
     #[msg("Authority mismatch")]
     AuthorityMismatch,
+    #[msg("Invalid timestamp")]
+    InvalidTimestamp,
 }

--- a/programs/protocol_event/src/instructions/create_grouping.rs
+++ b/programs/protocol_event/src/instructions/create_grouping.rs
@@ -22,11 +22,11 @@ pub fn create_category(
 
 fn validate_category(code: &String, name: &String) -> Result<()> {
     require!(
-        code.len() <= Subcategory::MAX_CODE_LENGTH,
+        code.len() <= Category::MAX_CODE_LENGTH,
         EventError::MaxStringLengthExceeded,
     );
     require!(
-        name.len() <= Subcategory::MAX_NAME_LENGTH,
+        name.len() <= Category::MAX_NAME_LENGTH,
         EventError::MaxStringLengthExceeded,
     );
     Ok(())

--- a/programs/protocol_event/src/instructions/update_grouping.rs
+++ b/programs/protocol_event/src/instructions/update_grouping.rs
@@ -13,7 +13,7 @@ pub fn increment_subcategory_participant_count(subcategory: &mut Subcategory) ->
 
 pub fn update_category_name(category: &mut Category, updated_name: String) -> Result<()> {
     require!(
-        updated_name.len() <= EventGroup::MAX_NAME_LENGTH,
+        updated_name.len() <= Category::MAX_NAME_LENGTH,
         EventError::MaxStringLengthExceeded,
     );
 
@@ -24,7 +24,7 @@ pub fn update_category_name(category: &mut Category, updated_name: String) -> Re
 
 pub fn update_subcategory_name(category: &mut Subcategory, updated_name: String) -> Result<()> {
     require!(
-        updated_name.len() <= EventGroup::MAX_NAME_LENGTH,
+        updated_name.len() <= Subcategory::MAX_NAME_LENGTH,
         EventError::MaxStringLengthExceeded,
     );
 

--- a/programs/protocol_event/src/state/category.rs
+++ b/programs/protocol_event/src/state/category.rs
@@ -1,4 +1,4 @@
-use crate::state::type_size::{vec_size, CHAR_SIZE, PUB_KEY_SIZE};
+use crate::state::type_size::{vec_size, CHAR_SIZE, DISCRIMINATOR_SIZE, PUB_KEY_SIZE};
 use anchor_lang::prelude::*;
 
 #[account]
@@ -13,7 +13,8 @@ impl Category {
     pub const MAX_CODE_LENGTH: usize = 8;
     pub const MAX_NAME_LENGTH: usize = 50;
 
-    pub const SIZE: usize = PUB_KEY_SIZE * 2
+    pub const SIZE: usize = DISCRIMINATOR_SIZE
+        + PUB_KEY_SIZE * 2
         + vec_size(CHAR_SIZE, Category::MAX_CODE_LENGTH)
         + vec_size(CHAR_SIZE, Category::MAX_NAME_LENGTH);
 }

--- a/programs/protocol_event/src/state/event_group.rs
+++ b/programs/protocol_event/src/state/event_group.rs
@@ -1,4 +1,4 @@
-use crate::state::type_size::{vec_size, CHAR_SIZE, PUB_KEY_SIZE};
+use crate::state::type_size::{vec_size, CHAR_SIZE, DISCRIMINATOR_SIZE, PUB_KEY_SIZE};
 use anchor_lang::prelude::*;
 
 #[account]
@@ -14,7 +14,8 @@ impl EventGroup {
     pub const MAX_CODE_LENGTH: usize = 8;
     pub const MAX_NAME_LENGTH: usize = 50;
 
-    pub const SIZE: usize = PUB_KEY_SIZE * 3
+    pub const SIZE: usize = DISCRIMINATOR_SIZE
+        + PUB_KEY_SIZE * 3
         + vec_size(CHAR_SIZE, EventGroup::MAX_CODE_LENGTH)
         + vec_size(CHAR_SIZE, EventGroup::MAX_NAME_LENGTH);
 }

--- a/programs/protocol_event/src/state/subcategory.rs
+++ b/programs/protocol_event/src/state/subcategory.rs
@@ -1,4 +1,4 @@
-use crate::state::type_size::{vec_size, CHAR_SIZE, PUB_KEY_SIZE, U16_SIZE};
+use crate::state::type_size::{vec_size, CHAR_SIZE, DISCRIMINATOR_SIZE, PUB_KEY_SIZE, U16_SIZE};
 use anchor_lang::prelude::*;
 
 #[account]
@@ -15,7 +15,8 @@ impl Subcategory {
     pub const MAX_CODE_LENGTH: usize = 8;
     pub const MAX_NAME_LENGTH: usize = 50;
 
-    pub const SIZE: usize = PUB_KEY_SIZE * 3
+    pub const SIZE: usize = DISCRIMINATOR_SIZE
+        + PUB_KEY_SIZE * 3
         + vec_size(CHAR_SIZE, Subcategory::MAX_CODE_LENGTH)
         + vec_size(CHAR_SIZE, Subcategory::MAX_NAME_LENGTH)
         + U16_SIZE;


### PR DESCRIPTION
Fix the remaining code issues from the audit. Each commit fixes one of these audit issues so feel free to review commit-by-commit.
* [L-2] Typo EventGroup::MAX_NAME_LENGTH at line 15 should be Category::MAX_NAME_LENGTH
* [L-3] Discriminator size DISCRIMINATOR_SIZE is not included when calculating the account size
* [I-1] Time stamp validation:
    *  `validate_event` doesn't validate the timestamps,
    * `update_expected_start_timestamp / update_actual_start_timestamp` doesn't validate if
the updated start timestamp is smaller than the `actual_end_timestamp` (if not None)
    * `update_actual_end_timestamp` doesn't validate if the updated end timestamp is larger
than the start time stamp.